### PR TITLE
allow prefix in base_footprint link

### DIFF
--- a/cyton_gamma_1500_macros.urdf.xacro
+++ b/cyton_gamma_1500_macros.urdf.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="cyton_gamma_1500">
 
   <xacro:macro name="base_footprint" params="prefix">
-    <link name="base_footprint">
+    <link name="${prefix}base_footprint">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -15,7 +15,7 @@
     </link>
 
     <joint name="base_joint" type="fixed">
-      <parent link="base_footprint" />
+      <parent link="${prefix}base_footprint" />
       <child link="${prefix}base_link" />
       <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
     </joint>


### PR DESCRIPTION
Typically base_footprint is a transformation name used for the robot, not for the arm.
This fix allows for base_footprint to be called with a prefix, for example arm_base_footprint or left_arm_footprint etc.
